### PR TITLE
nuplayer: Fix the "Fix CTS issues in NuPlayer"

### DIFF
--- a/media/libmediaplayerservice/nuplayer/GenericSource.cpp
+++ b/media/libmediaplayerservice/nuplayer/GenericSource.cpp
@@ -608,11 +608,6 @@ void NuPlayer::GenericSource::notifyBufferingUpdate(int percentage,
 status_t NuPlayer::GenericSource::getCachedDuration(int64_t *cachedDurationUs) {
     status_t finalStatus = UNKNOWN_ERROR;
 
-    if (mDurationUs > 0) {
-        *cachedDurationUs = mDurationUs;
-        return OK;
-    }
-
     if (mCachedSource != NULL) {
         size_t cachedDataRemaining =
                 mCachedSource->approxDataRemaining(&finalStatus);
@@ -632,6 +627,9 @@ status_t NuPlayer::GenericSource::getCachedDuration(int64_t *cachedDurationUs) {
     } else if (mWVMExtractor != NULL) {
         *cachedDurationUs
             = mWVMExtractor->getCachedDurationUs(&finalStatus);
+    } else if (mDurationUs > 0) {
+        *cachedDurationUs = mDurationUs;
+        return OK;
     }
 
     if (*cachedDurationUs > 0) {


### PR DESCRIPTION
If I play music with Google Play Music and then pause it, I have
two sources that are still polling for buffering updates in
the background.  This shows up in the log as

info/warning: (702,0)

Digging into it, the quoted change causes getCachedDuration to
never return the end of stream status (it always returns 0)
instead.

Fix this by not short-cutting sources that can do their own
cached lookup and instead move the new code down further in
the logic.

Change-Id: I7382561e2b3127016eb72307ed3c7f4e1fecc7b4