### PR TITLE
audioflinger: Fix glitches and volume ramp issue

### DIFF
--- a/services/audioflinger/AudioFlinger.cpp
+++ b/services/audioflinger/AudioFlinger.cpp
@@ -1546,7 +1546,7 @@ AudioFlinger::Client::Client(const sp<AudioFlinger>& audioFlinger, pid_t pid)
     :   RefBase(),
         mAudioFlinger(audioFlinger),
         // FIXME should be a "k" constant not hard-coded, in .h or ro. property, see 4 lines below
-        mMemoryDealer(new MemoryDealer(1028*1024, "AudioFlinger::Client")), //1MB + 1 more 4k page
+        mMemoryDealer(new MemoryDealer(2048*1024, "AudioFlinger::Client")), //2MB
         mPid(pid),
         mTimedTrackCount(0)
 {

--- a/services/audioflinger/AudioMixer.cpp
+++ b/services/audioflinger/AudioMixer.cpp
@@ -76,7 +76,7 @@ static const bool kUseNewMixer = true;
 // Set kUseFloat to true to allow floating input into the mixer engine.
 // If kUseNewMixer is false, this is ignored or may be overridden internally
 // because of downmix/upmix support.
-static const bool kUseFloat = true;
+static const bool kUseFloat = false;
 
 // Set to default copy buffer size in frames for input processing.
 static const size_t kCopyBufferFrameCount = 256;


### PR DESCRIPTION
 * Floating point support in the new mixer is not quite ready
   for prime time, and we have a number of failure cases.
 * Currently, we need features from the new mixer (multichannel,
   rebuffering) to support our codecs which output hires formats.
   These formats are all currently integer based (32-bit) and
   don't actually need float support.
 * Disable it for now to fix the issues until they are debugged.
 * Additionally, increase the size of the control block to deal
   with certain streams.

Change-Id: I8ee313193b24aa66e422f36d6c1c5359d025052c