### PR TITLE
Revert "Flush the audio sink if NuPlayerRenderer is paused during a flus...

### DIFF
--- a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
@@ -1123,13 +1123,6 @@ void NuPlayer::Renderer::onFlush(const sp<AMessage> &msg) {
             mAudioSink->flush();
             mAudioSink->start();
         }
-
-        if (mPaused) {
-            mAudioSink->flush();
-            mAnchorTimeMediaUs = -1;
-            mAnchorTimeRealUs = -1;
-            mNumFramesWritten = 0;
-        }
     } else {
         flushQueue(&mVideoQueue);
 


### PR DESCRIPTION
...h"

 * Causes nasty AV desync after seeks during offload playback.

This reverts commit 33a4c907402dc92bb9befff0609689b8783a71c9.

Change-Id: Icb8e581a73e4e2d8d484e7ec3b1875e45d729a8f