### PR TITLE
cameraservice: Resolve message vs start/stop preview races

### DIFF
--- a/services/camera/libcameraservice/api1/CameraClient.cpp
+++ b/services/camera/libcameraservice/api1/CameraClient.cpp
@@ -364,12 +364,14 @@ status_t CameraClient::setPreviewCallbackTarget(
 
 // start preview mode
 status_t CameraClient::startPreview() {
+    Mutex::Autolock lock(mLock);
     LOG1("startPreview (pid %d)", getCallingPid());
     return startCameraMode(CAMERA_PREVIEW_MODE);
 }
 
 // start recording mode
 status_t CameraClient::startRecording() {
+    Mutex::Autolock lock(mLock);
     LOG1("startRecording (pid %d)", getCallingPid());
     return startCameraMode(CAMERA_RECORDING_MODE);
 }
@@ -377,7 +379,6 @@ status_t CameraClient::startRecording() {
 // start preview or recording
 status_t CameraClient::startCameraMode(camera_mode mode) {
     LOG1("startCameraMode(%d)", mode);
-    Mutex::Autolock lock(mLock);
     status_t result = checkPidAndHardware();
     if (result != NO_ERROR) return result;
 


### PR DESCRIPTION
Move the mutex in start/stopPreview to include the metadata message
management. Fast start/stop sequences could (and would) eventually
cause the messages to be enabled/disabled out of sequence (or while
the camera wasn't ready for it)

This is a port of I367bc45729ce2e858fea972f35e881a755c6021a from cm-11

Change-Id: I9a065f951f628d1c550acbac18493b9ad3853d03